### PR TITLE
Added an error event handler to the post request to prevent thrown error...

### DIFF
--- a/lib/bunyan-slack.js
+++ b/lib/bunyan-slack.js
@@ -54,7 +54,9 @@ BunyanSlack.prototype.write = function write(record) {
 	request.post({
 		url: this.webhook_url,
 		body: JSON.stringify(message)
-	});
+	}).on('error', function(err) {
+        // Error handler to prevent thrown errors from crashing the program.
+    });
 };
 
 module.exports = BunyanSlack;


### PR DESCRIPTION
Added an error event handler to the post request to prevent thrown errors from crashing the program.  One example where this would happen is when the network is temporarily disconnected.  The error event handler doesn't need to do anything, it just needs to be there so that errors don't get thrown by Node's dns.js when it can't resolve the DNS name for slack.com during the request.post.

Here's the error message I was getting:
[Error: getaddrinfo ENOTFOUND] code: 'ENOTFOUND', errno: 'ENOTFOUND', syscall: 'getaddrinfo'

To test this you can temporarily disable your ethernet adapter (or unplug the ethernet cable) and run the test program.