### PR TITLE
make channel nullable to use default defined channel for webhook

### DIFF
--- a/lib/bunyan-slack.js
+++ b/lib/bunyan-slack.js
@@ -12,9 +12,12 @@ function BunyanSlack(options, error) {
 		this.webhook_url     = options.webhook_url || options.webhookUrl;
 		this.icon_url        = options.icon_url    || options.iconUrl;
 		this.icon_emoji      = options.icon_emoji  || options.iconEmoji;
-		this.channel         = options.channel     || '#general';
 		this.username        = options.username    || 'Bunyan Slack';
 		this.error           = error               || function() {};
+
+		if (typeof options.channel === 'undefined' || options.channel) {
+			this.channel = options.channel || '#general';
+		}
 
 		if (!this.icon_url && !this.icon_emoji) {
 			this.icon_emoji = ':scream_cat:';

--- a/test/bunyan_slack_test.js
+++ b/test/bunyan_slack_test.js
@@ -82,6 +82,29 @@ describe('bunyan-slack', function() {
 			sinon.assert.calledWith(request.post, expectedResponse);
 		});
 
+		it('should allow nullable channel', function() {
+			var log = Bunyan.createLogger({
+				name: 'myapp',
+				stream: new BunyanSlack({
+					webhook_url: 'mywebhookurl',
+					channel: null
+				}),
+				level: 'info'
+			});
+
+			var expectedResponse = {
+					body: JSON.stringify({
+						username: 'Bunyan Slack',
+						icon_emoji: ':scream_cat:',
+						text: '[INFO] foobar'
+					}),
+					url: 'mywebhookurl'
+			};
+
+			log.info('foobar');
+			sinon.assert.calledWith(request.post, expectedResponse);
+		});
+
 		it('should use the custom formatter', function() {
 			var log = Bunyan.createLogger({
 				name: 'myapp',


### PR DESCRIPTION
When creating a webhook, slack lets you set up a default channel to post to. Currently, `bunyan-slack` has no way of utilizing this feature, because you either explicitly define it as an option or it gets set to `#general`.

This PR makes it possible to pass `null` or `false` as channel to use the default, pre-defined option. Ideally, I'd just like this to be the default behavior for all options, but that would be a breaking change, so unless someone gives me the green light to do so, I won't go into that.
