### PR TITLE
Add editorconfig to simplify contributions in consistent style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# Set this file as the topmost .editorconfig
+root = true
+
+[*.{js,json}]
+indent_style = tab
+indent_size = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
The use of tabs threw my editor off a little. This PR adds an [editorconfig](http://editorconfig.org/) that simplifies contributions by allowing editors to automatically adjust to the correct style.