### PR TITLE
Add level filtering option to stream

### DIFF
--- a/lib/bunyan-slack.js
+++ b/lib/bunyan-slack.js
@@ -1,5 +1,6 @@
 var util = require('util'),
 request  = require('request'),
+bunyan = require('bunyan'),
 extend   = require('extend.js');
 
 function BunyanSlack(options, error) {
@@ -11,6 +12,7 @@ function BunyanSlack(options, error) {
 		this.customFormatter = options.customFormatter;
 		this.webhook_url     = options.webhook_url || options.webhookUrl;
 		this.error           = error               || function() {};
+		this.level           = options.level;
 
 		if (options.icon_url || options.iconUrl) {
 			this.icon_url = options.icon_url || options.iconUrl;
@@ -47,6 +49,10 @@ BunyanSlack.prototype.write = function write(record) {
 
 	if (typeof record === 'string') {
 		record = JSON.parse(record);
+	}
+
+	if (self.level && record.level < bunyan.resolveLevel(self.level)) {
+		return;
 	}
 
 	levelName = nameFromLevel[record.level];

--- a/test/bunyan_slack_test.js
+++ b/test/bunyan_slack_test.js
@@ -215,6 +215,21 @@ describe('bunyan-slack', function() {
 			sinon.assert.calledWith(request.post, expectedResponse);
 		});
 	});
-});
 
+	describe('log levels', function () {
+		it('should log according to stream log level', function () {
+			var log = Bunyan.createLogger({
+				name: 'myapp',
+				stream: new BunyanSlack({
+					webhook_url: 'mywebhookurl',
+					level: 'error'
+				}),
+				level: 'info'
+			});
+
+			log.info('foobar');
+			sinon.assert.notCalled(request.post);
+		});
+	});
+});
 


### PR DESCRIPTION
Fixes #16 
Adds a level property to BunyanSlack constructor and ignores lower level errors if specified.